### PR TITLE
Use Azure Monitor OpenTelemetry distro with Redis instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # how-to-create-software
+
+Project showcasing Azure Monitor OpenTelemetry integration.

--- a/otel_python/README.md
+++ b/otel_python/README.md
@@ -10,6 +10,7 @@ docker compose up --build
 ```
 
 The `frontend` is available on http://localhost:5173 and the API on http://localhost:8000.
+The Aspire observability dashboard is available on http://localhost:18888 when running in the default (non-Azure Monitor) mode.
 
 ## Tests
 

--- a/otel_python/README.md
+++ b/otel_python/README.md
@@ -1,7 +1,7 @@
 # OTEL Python Demo
 
 This demo shows a React frontend, FastAPI backend and background worker processing tasks via Redis.
-OpenTelemetry traces from all services are sent to an Aspire dashboard.
+Telemetry is sent to Azure Monitor when an Application Insights connection string or instrumentation key is supplied. Otherwise, the services use the native OpenTelemetry SDK and export to the Aspire dashboard. The provided `docker compose` setup runs in this Aspire mode by default.
 
 ## Running the stack
 
@@ -9,7 +9,7 @@ OpenTelemetry traces from all services are sent to an Aspire dashboard.
 docker compose up --build
 ```
 
-The `frontend` is available on http://localhost:5173, the API on http://localhost:8000 and the Aspire dashboard on http://localhost:18888.
+The `frontend` is available on http://localhost:5173 and the API on http://localhost:8000.
 
 ## Tests
 

--- a/otel_python/api/app/main.py
+++ b/otel_python/api/app/main.py
@@ -12,14 +12,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
 
-# Example from Azure docs on initializing the distro:
-# import logging
-# from azure.monitor.opentelemetry import configure_azure_monitor
-# configure_azure_monitor(
-#     logger_name="<your_logger_namespace>",
-# )
-# logger = logging.getLogger("<your_logger_namespace>")
-
 app = FastAPI()
 
 ai_conn = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")

--- a/otel_python/api/app/main.py
+++ b/otel_python/api/app/main.py
@@ -1,7 +1,40 @@
 import json
+import os
 import uuid
+
 import redis.asyncio as redis
 from fastapi import Body, FastAPI
+from azure.monitor.opentelemetry import configure_azure_monitor
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.redis import RedisInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
+
+# Example from Azure docs on initializing the distro:
+# import logging
+# from azure.monitor.opentelemetry import configure_azure_monitor
+# configure_azure_monitor(
+#     logger_name="<your_logger_namespace>",
+# )
+# logger = logging.getLogger("<your_logger_namespace>")
+
+app = FastAPI()
+
+ai_conn = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+ai_key = os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY") or os.getenv(
+    "APPLICATIONINSIGHTS_INSTRUMENTATION_KEY"
+)
+if ai_conn or ai_key:
+    configure_azure_monitor()
+else:
+    provider = TracerProvider(resource=Resource.create({"service.name": "api"}))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+FastAPIInstrumentor().instrument_app(app)
+RedisInstrumentor().instrument()
 
 QUEUE = "tasks"
 RESULTS = "results"
@@ -11,8 +44,6 @@ async def enqueue(kind: str, payload: str) -> str:
     task_id = str(uuid.uuid4())
     await r.rpush(QUEUE, json.dumps({"id": task_id, "kind": kind, "data": payload}))
     return task_id
-
-app = FastAPI()
 
 @app.post("/task1")
 async def task1(payload: str = Body(...)):

--- a/otel_python/api/app/worker.py
+++ b/otel_python/api/app/worker.py
@@ -10,14 +10,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
 
-# Example from Azure docs on initializing the distro:
-# import logging
-# from azure.monitor.opentelemetry import configure_azure_monitor
-# configure_azure_monitor(
-#     logger_name="<your_logger_namespace>",
-# )
-# logger = logging.getLogger("<your_logger_namespace>")
-
 ai_conn = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
 ai_key = os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY") or os.getenv(
     "APPLICATIONINSIGHTS_INSTRUMENTATION_KEY"

--- a/otel_python/api/app/worker.py
+++ b/otel_python/api/app/worker.py
@@ -1,8 +1,35 @@
 import asyncio
 import json
 import os
+
 import redis.asyncio as redis
+from azure.monitor.opentelemetry import configure_azure_monitor
 from opentelemetry import trace
+from opentelemetry.instrumentation.redis import RedisInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
+
+# Example from Azure docs on initializing the distro:
+# import logging
+# from azure.monitor.opentelemetry import configure_azure_monitor
+# configure_azure_monitor(
+#     logger_name="<your_logger_namespace>",
+# )
+# logger = logging.getLogger("<your_logger_namespace>")
+
+ai_conn = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+ai_key = os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY") or os.getenv(
+    "APPLICATIONINSIGHTS_INSTRUMENTATION_KEY"
+)
+if ai_conn or ai_key:
+    configure_azure_monitor()
+else:
+    provider = TracerProvider(resource=Resource.create({"service.name": "worker"}))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+RedisInstrumentor().instrument()
 
 QUEUE = "tasks"
 RESULTS = "results"

--- a/otel_python/api/requirements.txt
+++ b/otel_python/api/requirements.txt
@@ -2,8 +2,8 @@ fastapi==0.116.1
 uvicorn==0.32.0
 redis[asyncio]==6.4.0
 requests==2.32.4
+azure-monitor-opentelemetry==1.7.0
 opentelemetry-sdk==1.36.0
 opentelemetry-exporter-otlp==1.36.0
 opentelemetry-instrumentation-fastapi==0.57b0
 opentelemetry-instrumentation-redis==0.57b0
-opentelemetry-distro==0.57b0

--- a/otel_python/docker-compose.yml
+++ b/otel_python/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   api:
     build: .
     working_dir: /app/api
-    command: opentelemetry-instrument uvicorn app.main:app --host 0.0.0.0 --port 8000
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
     environment:
@@ -25,7 +25,7 @@ services:
   worker:
     build: .
     working_dir: /app/api
-    command: opentelemetry-instrument python -m app.worker
+    command: python -m app.worker
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf


### PR DESCRIPTION
## Summary
- switch API and worker tracing to Azure Monitor distro when an Application Insights connection string or instrumentation key is present
- fall back to native OTLP export to the Aspire collector otherwise, while enabling Redis spans
- document new Azure Monitor configuration and update dependencies

## Testing
- `python -m py_compile otel_python/api/app/main.py otel_python/api/app/worker.py`
- `python -m unittest otel_python.tests.test_e2e -v` *(fails: API not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f7028a483238922ed522d5de203